### PR TITLE
Ruby dependency, make unicorn prod server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,13 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.1', '>= 5.2.1.1'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.3.6'
-# Use Puma as the app server
-gem 'puma', '~> 3.11'
+# Use Puma for dev and Unicorn for prod as the app server
+gem 'puma', '~> 3.11', group: :development
+gem 'unicorn', '~> 5.5', group: :production
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets


### PR DESCRIPTION
Remove Ruby version dependecy as it is not needed that strong.
We use unicorn for production.